### PR TITLE
 k3gxx: leds: lp5622: handle on_delay=0 as Power OFF Command

### DIFF
--- a/drivers/leds/leds-lp5562.c
+++ b/drivers/leds/leds-lp5562.c
@@ -694,15 +694,13 @@ static ssize_t lp5562_store_blink(struct device *dev,
 	pr_info("%s: 0x%08x %d %d\n", __func__, rgb, on, off);
 
 	if (on == 0) {
-        pr_info("%s: wrong on/off time. on: %d, off: %d\n",
-            __func__, on, off);
-        return len;
-    }
-    if (off == 0) {
-        pr_info("%s: off time. on: %d, off: %d\n",
-            __func__, on, off);
-
-    }
+		pr_info("%s: led engines stopped !",
+			__func__);
+	}
+	if (off == 0) {
+		pr_info("%s: off time. on: %d, off: %d\n",
+			__func__, on, off);
+	}
 
 	lp5562_stop_engine(chip);
 


### PR DESCRIPTION
Our Lights HAL write "0x00000000 0 0" when It wants to Clear Previous Blink Commands,
but Our Kernel Driver doesn't support 0 as on_delay_time. This Patch can solve the problem aka "LED Blinking Issue"

Credit : @aarani
Change-Id: Ie6d23fcdbccc950978fe8d7be287dbe9bcfae27c